### PR TITLE
Get rid of some 2.7 “feature” workarounds

### DIFF
--- a/examples/breakout/breakout_simple_connection.py
+++ b/examples/breakout/breakout_simple_connection.py
@@ -1,5 +1,3 @@
-from __future__ import print_function
-
 # non-SpiNNaker imports
 import matplotlib.pyplot as plt
 import numpy as np

--- a/requirements-test.txt
+++ b/requirements-test.txt
@@ -2,4 +2,4 @@
 flake8
 pytest>=2.8
 pytest-cov
-sphinx==1.5.3
+sphinx >= 2

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,8 +6,6 @@ SpiNNaker_DataSpecification >= 1!5.0.1, < 1!6.0.0
 SpiNNFrontEndCommon >= 1!5.0.1, < 1!6.0.0
 sPyNNaker >= 1!5.0.1, < 1!6.0.0
 sPyNNaker8 >= 1!5.0.1, < 1!6.0.0
-numpy == 1.16; python_version == '2.7'
-numpy == 1.18; python_version == '3.5'
 numpy == 1.19; python_version == '3.6'
 numpy >= 1.19, <= 1.20; python_version == '3.7'
 numpy; python_version >= '3.8'

--- a/setup.py
+++ b/setup.py
@@ -13,8 +13,6 @@ install_requires = [
     'SpiNNaker_DataSpecification >= 1!5.0.1, < 1!6.0.0',
     'spalloc >= 2.0.2, < 3.0.0',
     'SpiNNFrontEndCommon >= 1!5.0.1, < 1!6.0.0',
-    "numpy == 1.16; python_version == '2.7'",
-    "numpy == 1.18; python_version == '3.5'",
     "numpy == 1.19; python_version == '3.6'",
     "numpy >= 1.19, <= 1.20; python_version == '3.7'",
     "numpy; python_version >= '3.8'",


### PR DESCRIPTION
Python 2.7 is really on its last legs now. PyPI and pip are beginning to withdraw support; the next security update will probably kill things entirely.

Fortunately, this repo is already in the Brave New World (of only checking with 3.6 or later) so all this is doing is clearing up a few idioms that have sneaked in from elsewhere that aren't damaging here but don't need to be kept. _This can be merged immediately._