### PR TITLE
Stop bat from auto-moving towards the left corner

### DIFF
--- a/c_code/breakout/src/bkout.c
+++ b/c_code/breakout/src/bkout.c
@@ -366,10 +366,10 @@ static void update_frame (uint32_t time)
 
     // Update bat and clamp
     if (move_direction == KEY_LEFT && --x_bat < 0) {
-        x_bat = 0;
+        x_bat = 1;
     }
     else if (move_direction == KEY_RIGHT && ++x_bat > GAME_WIDTH-bat_len) {
-        x_bat = GAME_WIDTH-bat_len;
+        x_bat = GAME_WIDTH - bat_len - 1;
     }
 
     // Clear keystate


### PR DESCRIPTION
Had forgotten I found this modification on an older project which fixes the behaviour of the bat in the visualiser to be more "random", rather than auto-moving to the left.

To credit the original commit, it's here: https://github.com/SpiNNakerManchester/SpiNNGym/commit/fb4dd83802e5236a402e7485ccc124ddad1e09fb