### PR TITLE
Do version in the same way as other repositoires

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -17,7 +17,8 @@ import os
 from setuptools import setup
 from collections import defaultdict
 
-__version__ = 1.0
+__version__ = None
+exec(open("spinn_gym/_version.py").read())
 assert __version__
 
 install_requires = [

--- a/spinn_gym/_version.py
+++ b/spinn_gym/_version.py
@@ -1,0 +1,20 @@
+# Copyright (c) 2017 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+__version__ = "1!5.1.1"
+__version_month__ = "November"
+__version_year__ = "2019"
+__version_day__ = "15"
+__version_name__ = "Liveware Problem"


### PR DESCRIPTION
This was the only place where setup.py hard the version in it rather than get it from _version.py

Unifying this will make automatic version bumping easier.

If this goes in before the release the release branch will need updating but that would be a good thing.