### PR TITLE
Stop passing config values through the simulator

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -54,13 +54,13 @@ jobs:
 #      with:
 #        board-address: spinn-4.cs.man.ac.uk
 #
-#    - name: Test with pytest
-#      uses: ./support/actions/pytest
-#      with:
-#        tests: unittests
-#        coverage: ${{ matrix.python-version == 3.6 }}
-#        cover-packages: ${{ env.CODE_PATHS }}
-#        coveralls-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
+    - name: Test with pytest
+      uses: ./support/actions/pytest
+      with:
+        tests: unittests
+        coverage: ${{ matrix.python-version == 3.6 }}
+        cover-packages: ${{ env.CODE_PATHS }}
+        coveralls-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
 
     - name: Lint with flake8
       run: flake8 examples spinn_gym

--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -48,12 +48,12 @@ jobs:
     - name: Setup
       uses: ./support/actions/run-setup
 
-#    # Add this when tests are built
-#    - name: Create a spynnaker.cfg
-#      uses: ./support/actions/configure-spynnaker
-#      with:
-#        board-address: spinn-4.cs.man.ac.uk
-#
+    # Add this when tests are built
+    - name: Create a spynnaker.cfg
+      uses: ./support/actions/configure-spynnaker
+      with:
+        board-address: spinn-4.cs.man.ac.uk
+
     - name: Test with pytest
       uses: ./support/actions/pytest
       with:

--- a/examples/breakout/breakout_simple_connection.py
+++ b/examples/breakout/breakout_simple_connection.py
@@ -22,7 +22,6 @@ import subprocess
 import sys
 
 # SpiNNaker imports
-from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 from spinn_front_end_common.utilities.database.database_connection \
     import DatabaseConnection
@@ -68,8 +67,7 @@ def get_scores(breakout_pop, simulator):
     b_vertex = breakout_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager,
-        get_config_int("Machine", "machine_time_step"))
+        simulator.buffer_manager)
 
     return scores.tolist()
 

--- a/examples/breakout/breakout_simple_connection.py
+++ b/examples/breakout/breakout_simple_connection.py
@@ -22,6 +22,7 @@ import subprocess
 import sys
 
 # SpiNNaker imports
+from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 from spinn_front_end_common.utilities.database.database_connection \
     import DatabaseConnection
@@ -67,7 +68,8 @@ def get_scores(breakout_pop, simulator):
     b_vertex = breakout_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager, simulator.machine_time_step)
+        simulator.buffer_manager,
+        get_config_int("Machine", "machine_time_step"))
 
     return scores.tolist()
 

--- a/examples/double_inverted_pendulum/double_inverted_pendulum_test.py
+++ b/examples/double_inverted_pendulum/double_inverted_pendulum_test.py
@@ -19,7 +19,6 @@ from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import spinn_gym as gym
 # from spinn_arm.python_models.arm import Arm
-from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -27,8 +26,7 @@ def get_scores(game_pop, simulator):
     g_vertex = game_pop._vertex
     scores = g_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager,
-        get_config_int("Machine", "machine_time_step"))
+        simulator.buffer_manager)
     return scores.tolist()
 
 

--- a/examples/double_inverted_pendulum/double_inverted_pendulum_test.py
+++ b/examples/double_inverted_pendulum/double_inverted_pendulum_test.py
@@ -19,6 +19,7 @@ from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import spinn_gym as gym
 # from spinn_arm.python_models.arm import Arm
+from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -26,7 +27,8 @@ def get_scores(game_pop, simulator):
     g_vertex = game_pop._vertex
     scores = g_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager, simulator.machine_time_step)
+        simulator.buffer_manager,
+        get_config_int("Machine", "machine_time_step"))
     return scores.tolist()
 
 

--- a/examples/inverted_pendulum/inverted_pendulum_test.py
+++ b/examples/inverted_pendulum/inverted_pendulum_test.py
@@ -21,7 +21,6 @@ import matplotlib.pyplot as plt
 # SpiNNaker imports
 import spynnaker8 as p
 import spinn_gym as gym
-from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -29,8 +28,7 @@ def get_scores(game_pop, simulator):
     g_vertex = game_pop._vertex
     scores = g_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager,
-        get_config_int("Machine", "machine_time_step"))
+        simulator.buffer_manager)
     return scores.tolist()
 
 

--- a/examples/inverted_pendulum/inverted_pendulum_test.py
+++ b/examples/inverted_pendulum/inverted_pendulum_test.py
@@ -21,6 +21,7 @@ import matplotlib.pyplot as plt
 # SpiNNaker imports
 import spynnaker8 as p
 import spinn_gym as gym
+from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -28,7 +29,8 @@ def get_scores(game_pop, simulator):
     g_vertex = game_pop._vertex
     scores = g_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager, simulator.machine_time_step)
+        simulator.buffer_manager,
+        get_config_int("Machine", "machine_time_step"))
     return scores.tolist()
 
 

--- a/examples/logic/logic_test.py
+++ b/examples/logic/logic_test.py
@@ -19,6 +19,7 @@ import spinn_gym as gym
 from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import numpy as np
+from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -26,7 +27,8 @@ def get_scores(logic_pop, simulator):
     b_vertex = logic_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager, simulator.machine_time_step)
+        simulator.buffer_manager,
+        get_config_int("Machine", "machine_time_step"))
     return scores.tolist()
 
 

--- a/examples/logic/logic_test.py
+++ b/examples/logic/logic_test.py
@@ -19,7 +19,6 @@ import spinn_gym as gym
 from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import numpy as np
-from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -27,8 +26,7 @@ def get_scores(logic_pop, simulator):
     b_vertex = logic_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager,
-        get_config_int("Machine", "machine_time_step"))
+        simulator.buffer_manager)
     return scores.tolist()
 
 

--- a/examples/multi_arm_bandit/bandit_test.py
+++ b/examples/multi_arm_bandit/bandit_test.py
@@ -19,6 +19,7 @@ import spinn_gym as gym
 from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import numpy as np
+from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -26,7 +27,8 @@ def get_scores(bandit_pop, simulator):
     b_vertex = bandit_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager, simulator.machine_time_step)
+        simulator.buffer_manager,
+        get_config_int("Machine", "machine_time_step"))
     return scores.tolist()
 
 

--- a/examples/multi_arm_bandit/bandit_test.py
+++ b/examples/multi_arm_bandit/bandit_test.py
@@ -19,7 +19,6 @@ import spinn_gym as gym
 from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import numpy as np
-from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -27,8 +26,7 @@ def get_scores(bandit_pop, simulator):
     b_vertex = bandit_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager,
-        get_config_int("Machine", "machine_time_step"))
+        simulator.buffer_manager)
     return scores.tolist()
 
 

--- a/examples/store_recall/store_recall_test.py
+++ b/examples/store_recall/store_recall_test.py
@@ -19,7 +19,6 @@ import spinn_gym as gym
 from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import numpy as np
-from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -27,8 +26,7 @@ def get_scores(recall_pop, simulator):
     b_vertex = recall_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager,
-        get_config_int("Machine", "machine_time_step"))
+        simulator.buffer_manager)
     return scores.tolist()
 
 

--- a/examples/store_recall/store_recall_test.py
+++ b/examples/store_recall/store_recall_test.py
@@ -19,6 +19,7 @@ import spinn_gym as gym
 from pyNN.utility.plotting import Figure, Panel
 import matplotlib.pyplot as plt
 import numpy as np
+from spinn_utilities.config_holder import get_config_int
 from spinn_front_end_common.utilities.globals_variables import get_simulator
 
 
@@ -26,7 +27,8 @@ def get_scores(recall_pop, simulator):
     b_vertex = recall_pop._vertex
     scores = b_vertex.get_data(
         'score', simulator.no_machine_time_steps, simulator.placements,
-        simulator.buffer_manager, simulator.machine_time_step)
+        simulator.buffer_manager,
+        get_config_int("Machine", "machine_time_step"))
     return scores.tolist()
 
 

--- a/spinn_gym/games/breakout/breakout.py
+++ b/spinn_gym/games/breakout/breakout.py
@@ -170,10 +170,6 @@ class Breakout(AbstractOneAppOneMachineVertex,
     def neurons(self):
         return self._n_neurons
 
-    def get_maximum_delay_supported_in_ms(self, machine_time_step):
-        # Breakout has no synapses so can simulate only one time step of delay
-        return machine_time_step / 1000.0
-
     @property
     @overrides(AbstractOneAppOneMachineVertex.n_atoms)
     def n_atoms(self):

--- a/spinn_gym/games/breakout/breakout.py
+++ b/spinn_gym/games/breakout/breakout.py
@@ -251,8 +251,8 @@ class Breakout(AbstractOneAppOneMachineVertex,
         return 10000  # 10 seconds hard coded in bkout.c
 
     @overrides(AbstractNeuronRecordable.get_data)
-    def get_data(self, variable, n_machine_time_steps, placements,
-                 buffer_manager, machine_time_step):
+    def get_data(
+            self, variable, n_machine_time_steps, placements, buffer_manager):
         vertex = self.machine_vertices.pop()
         placement = placements.get_placement_of_vertex(vertex)
 

--- a/spinn_gym/games/breakout/breakout_machine_vertex.py
+++ b/spinn_gym/games/breakout/breakout_machine_vertex.py
@@ -103,15 +103,11 @@ class BreakoutMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
     # ------------------------------------------------------------------------
     # AbstractGeneratesDataSpecification overrides
     # ------------------------------------------------------------------------
-    @inject_items({"machine_time_step": "MachineTimeStep",
-                   "time_scale_factor": "TimeScaleFactor",
-                   "routing_info": "MemoryRoutingInfos"})
+    @inject_items({"routing_info": "MemoryRoutingInfos"})
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification,
-               additional_arguments={"machine_time_step", "time_scale_factor",
-                                     "routing_info"}
+               additional_arguments={"routing_info"}
                )
-    def generate_data_specification(self, spec, placement, machine_time_step,
-                                    time_scale_factor, routing_info):
+    def generate_data_specification(self, spec, placement, routing_info):
         vertex = placement.vertex
 
         spec.comment("\n*** Spec for Breakout Instance ***\n\n")
@@ -138,8 +134,7 @@ class BreakoutMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
         spec.switch_write_focus(
             BreakoutMachineVertex._BREAKOUT_REGIONS.SYSTEM.value)
         spec.write_array(simulation_utilities.get_simulation_header_array(
-            vertex.get_binary_file_name(), machine_time_step,
-            time_scale_factor))
+            vertex.get_binary_file_name()))
 
         # Write breakout region containing routing key to transmit with
         spec.comment("\nWriting breakout region:\n")

--- a/spinn_gym/games/double_inverted_pendulum/double_pendulum.py
+++ b/spinn_gym/games/double_inverted_pendulum/double_pendulum.py
@@ -186,10 +186,6 @@ class DoublePendulum(AbstractOneAppOneMachineVertex,
     def neurons(self):
         return self._n_neurons
 
-    def get_maximum_delay_supported_in_ms(self, machine_time_step):
-        # Pendulum has no synapses so can simulate only one time step of delay
-        return machine_time_step / 1000.0
-
     @property
     @overrides(AbstractOneAppOneMachineVertex.n_atoms)
     def n_atoms(self):

--- a/spinn_gym/games/double_inverted_pendulum/double_pendulum.py
+++ b/spinn_gym/games/double_inverted_pendulum/double_pendulum.py
@@ -250,8 +250,8 @@ class DoublePendulum(AbstractOneAppOneMachineVertex,
         return 10000  # 10 seconds hard coded in bkout.c
 
     @overrides(AbstractNeuronRecordable.get_data)
-    def get_data(self, variable, n_machine_time_steps, placements,
-                 buffer_manager, machine_time_step):
+    def get_data(
+            self, variable, n_machine_time_steps, placements, buffer_manager):
         vertex = self.machine_vertices.pop()
         placement = placements.get_placement_of_vertex(vertex)
 

--- a/spinn_gym/games/double_inverted_pendulum/double_pendulum_machine_vertex.py
+++ b/spinn_gym/games/double_inverted_pendulum/double_pendulum_machine_vertex.py
@@ -111,15 +111,11 @@ class DoublePendulumMachineVertex(MachineVertex,
     # ------------------------------------------------------------------------
     # AbstractGeneratesDataSpecification overrides
     # ------------------------------------------------------------------------
-    @inject_items({"machine_time_step": "MachineTimeStep",
-                   "time_scale_factor": "TimeScaleFactor",
-                   "routing_info": "MemoryRoutingInfos"})
+    @inject_items({"routing_info": "MemoryRoutingInfos"})
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification,
-               additional_arguments={"machine_time_step", "time_scale_factor",
-                                     "routing_info"}
+               additional_arguments={"routing_info"}
                )
-    def generate_data_specification(self, spec, placement, machine_time_step,
-                                    time_scale_factor, routing_info):
+    def generate_data_specification(self, spec, placement, routing_info):
         vertex = placement.vertex
 
         spec.comment("\n*** Spec for Double Pendulum Instance ***\n\n")
@@ -146,8 +142,7 @@ class DoublePendulumMachineVertex(MachineVertex,
         spec.switch_write_focus(
             self._DOUBLE_PENDULUM_REGIONS.SYSTEM.value)
         spec.write_array(simulation_utilities.get_simulation_header_array(
-            vertex.get_binary_file_name(), machine_time_step,
-            time_scale_factor))
+            vertex.get_binary_file_name())
 
         # Write pendulum region containing routing key to transmit with
         spec.comment("\nWriting double pendulum region:\n")

--- a/spinn_gym/games/double_inverted_pendulum/double_pendulum_machine_vertex.py
+++ b/spinn_gym/games/double_inverted_pendulum/double_pendulum_machine_vertex.py
@@ -142,7 +142,7 @@ class DoublePendulumMachineVertex(MachineVertex,
         spec.switch_write_focus(
             self._DOUBLE_PENDULUM_REGIONS.SYSTEM.value)
         spec.write_array(simulation_utilities.get_simulation_header_array(
-            vertex.get_binary_file_name())
+            vertex.get_binary_file_name()))
 
         # Write pendulum region containing routing key to transmit with
         spec.comment("\nWriting double pendulum region:\n")

--- a/spinn_gym/games/inverted_pendulum/inverted_pendulum.py
+++ b/spinn_gym/games/inverted_pendulum/inverted_pendulum.py
@@ -182,10 +182,6 @@ class Pendulum(AbstractOneAppOneMachineVertex,
     def neurons(self):
         return self._n_neurons
 
-    def get_maximum_delay_supported_in_ms(self, machine_time_step):
-        # Pendulum has no synapses so can simulate only one time step of delay
-        return machine_time_step / 1000.0
-
     @property
     @overrides(AbstractOneAppOneMachineVertex.n_atoms)
     def n_atoms(self):

--- a/spinn_gym/games/inverted_pendulum/inverted_pendulum.py
+++ b/spinn_gym/games/inverted_pendulum/inverted_pendulum.py
@@ -246,8 +246,8 @@ class Pendulum(AbstractOneAppOneMachineVertex,
         return 10000  # 10 seconds hard coded in inverted_pendulum.c
 
     @overrides(AbstractNeuronRecordable.get_data)
-    def get_data(self, variable, n_machine_time_steps, placements,
-                 buffer_manager, machine_time_step):
+    def get_data(
+            self, variable, n_machine_time_steps, placements, buffer_manager):
         vertex = self.machine_vertices.pop()
         placement = placements.get_placement_of_vertex(vertex)
 

--- a/spinn_gym/games/inverted_pendulum/inverted_pendulum_machine_vertex.py
+++ b/spinn_gym/games/inverted_pendulum/inverted_pendulum_machine_vertex.py
@@ -111,15 +111,11 @@ class PendulumMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
     # ------------------------------------------------------------------------
     # AbstractGeneratesDataSpecification overrides
     # ------------------------------------------------------------------------
-    @inject_items({"machine_time_step": "MachineTimeStep",
-                   "time_scale_factor": "TimeScaleFactor",
-                   "routing_info": "MemoryRoutingInfos"})
+    @inject_items({"routing_info": "MemoryRoutingInfos"})
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification,
-               additional_arguments={"machine_time_step", "time_scale_factor",
-                                     "routing_info"}
+               additional_arguments={"routing_info"}
                )
-    def generate_data_specification(self, spec, placement, machine_time_step,
-                                    time_scale_factor, routing_info):
+    def generate_data_specification(self, spec, placement, routing_info):
         vertex = placement.vertex
 
         spec.comment("\n*** Spec for Pendulum Instance ***\n\n")
@@ -146,8 +142,7 @@ class PendulumMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
         spec.switch_write_focus(
             self._PENDULUM_REGIONS.SYSTEM.value)
         spec.write_array(simulation_utilities.get_simulation_header_array(
-            vertex.get_binary_file_name(), machine_time_step,
-            time_scale_factor))
+            vertex.get_binary_file_name()))
 
         # Write pendulum region containing routing key to transmit with
         spec.comment("\nWriting pendulum region:\n")

--- a/spinn_gym/games/logic/logic.py
+++ b/spinn_gym/games/logic/logic.py
@@ -172,10 +172,6 @@ class Logic(AbstractOneAppOneMachineVertex,
     def neurons(self):
         return self._n_neurons
 
-    def get_maximum_delay_supported_in_ms(self, machine_time_step):
-        # Logic has no synapses so can simulate only one time step of delay
-        return machine_time_step / 1000.0
-
     @property
     @overrides(AbstractOneAppOneMachineVertex.n_atoms)
     def n_atoms(self):

--- a/spinn_gym/games/logic/logic.py
+++ b/spinn_gym/games/logic/logic.py
@@ -236,8 +236,8 @@ class Logic(AbstractOneAppOneMachineVertex,
         return 10000  # 10 seconds hard coded in logic.c
 
     @overrides(AbstractNeuronRecordable.get_data)
-    def get_data(self, variable, n_machine_time_steps, placements,
-                 buffer_manager, machine_time_step):
+    def get_data(
+            self, variable, n_machine_time_steps, placements, buffer_manager):
         vertex = self.machine_vertices.pop()
         placement = placements.get_placement_of_vertex(vertex)
 

--- a/spinn_gym/games/logic/logic_machine_vertex.py
+++ b/spinn_gym/games/logic/logic_machine_vertex.py
@@ -99,15 +99,11 @@ class LogicMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
     # ------------------------------------------------------------------------
     # AbstractGeneratesDataSpecification overrides
     # ------------------------------------------------------------------------
-    @inject_items({"machine_time_step": "MachineTimeStep",
-                   "time_scale_factor": "TimeScaleFactor",
-                   "routing_info": "MemoryRoutingInfos"})
+    @inject_items({"routing_info": "MemoryRoutingInfos"})
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification,
-               additional_arguments={"machine_time_step", "time_scale_factor",
-                                     "routing_info"}
+               additional_arguments={"routing_info"}
                )
-    def generate_data_specification(self, spec, placement, machine_time_step,
-                                    time_scale_factor, routing_info):
+    def generate_data_specification(self, spec, placement, routing_info):
         vertex = placement.vertex
 
         spec.comment("\n*** Spec for Logic Instance ***\n\n")
@@ -136,8 +132,7 @@ class LogicMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
         spec.switch_write_focus(
             self._LOGIC_REGIONS.SYSTEM.value)
         spec.write_array(simulation_utilities.get_simulation_header_array(
-            vertex.get_binary_file_name(), machine_time_step,
-            time_scale_factor))
+            vertex.get_binary_file_name()))
 
         # Write logic region containing routing key to transmit with
         spec.comment("\nWriting logic region:\n")

--- a/spinn_gym/games/multi_arm_bandit/bandit.py
+++ b/spinn_gym/games/multi_arm_bandit/bandit.py
@@ -163,10 +163,6 @@ class Bandit(AbstractOneAppOneMachineVertex,
     def neurons(self):
         return self._n_neurons
 
-    def get_maximum_delay_supported_in_ms(self, machine_time_step):
-        # Bandit has no synapses so can simulate only one time step of delay
-        return machine_time_step / 1000.0
-
     @property
     @overrides(AbstractOneAppOneMachineVertex.n_atoms)
     def n_atoms(self):

--- a/spinn_gym/games/multi_arm_bandit/bandit.py
+++ b/spinn_gym/games/multi_arm_bandit/bandit.py
@@ -227,8 +227,8 @@ class Bandit(AbstractOneAppOneMachineVertex,
         return 10000  # 10 seconds hard coded in bkout.c
 
     @overrides(AbstractNeuronRecordable.get_data)
-    def get_data(self, variable, n_machine_time_steps, placements,
-                 buffer_manager, machine_time_step):
+    def get_data(
+            self, variable, n_machine_time_steps, placements, buffer_manager):
         vertex = self.machine_vertices.pop()
         placement = placements.get_placement_of_vertex(vertex)
 

--- a/spinn_gym/games/multi_arm_bandit/bandit_machine_vertex.py
+++ b/spinn_gym/games/multi_arm_bandit/bandit_machine_vertex.py
@@ -105,15 +105,11 @@ class BanditMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
     # ------------------------------------------------------------------------
     # AbstractGeneratesDataSpecification overrides
     # ------------------------------------------------------------------------
-    @inject_items({"machine_time_step": "MachineTimeStep",
-                   "time_scale_factor": "TimeScaleFactor",
-                   "routing_info": "MemoryRoutingInfos"})
+    @inject_items({"routing_info": "MemoryRoutingInfos"})
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification,
-               additional_arguments={"machine_time_step", "time_scale_factor",
-                                     "routing_info"}
+               additional_arguments={"routing_info"}
                )
-    def generate_data_specification(self, spec, placement, machine_time_step,
-                                    time_scale_factor, routing_info):
+    def generate_data_specification(self, spec, placement, routing_info):
         vertex = placement.vertex
 
         spec.comment("\n*** Spec for Bandit Instance ***\n\n")
@@ -141,8 +137,7 @@ class BanditMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
         spec.switch_write_focus(
             self._BANDIT_REGIONS.SYSTEM.value)
         spec.write_array(simulation_utilities.get_simulation_header_array(
-            vertex.get_binary_file_name(), machine_time_step,
-            time_scale_factor))
+            vertex.get_binary_file_name()))
 
         # Write bandit region containing routing key to transmit with
         spec.comment("\nWriting bandit region:\n")

--- a/spinn_gym/games/store_recall/store_recall.py
+++ b/spinn_gym/games/store_recall/store_recall.py
@@ -238,8 +238,8 @@ class Recall(AbstractOneAppOneMachineVertex,
         return 10000  # 10 seconds hard coded in store_recall.c
 
     @overrides(AbstractNeuronRecordable.get_data)
-    def get_data(self, variable, n_machine_time_steps, placements,
-                 buffer_manager, machine_time_step):
+    def get_data(
+            self, variable, n_machine_time_steps, placements, buffer_manager):
         vertex = self.machine_vertices.pop()
         placement = placements.get_placement_of_vertex(vertex)
 

--- a/spinn_gym/games/store_recall/store_recall.py
+++ b/spinn_gym/games/store_recall/store_recall.py
@@ -174,10 +174,6 @@ class Recall(AbstractOneAppOneMachineVertex,
     def neurons(self):
         return self._n_neurons
 
-    def get_maximum_delay_supported_in_ms(self, machine_time_step):
-        # Recall has no synapses so can simulate only one time step of delay
-        return machine_time_step / 1000.0
-
     @property
     @overrides(AbstractOneAppOneMachineVertex.n_atoms)
     def n_atoms(self):

--- a/spinn_gym/games/store_recall/store_recall_machine_vertex.py
+++ b/spinn_gym/games/store_recall/store_recall_machine_vertex.py
@@ -100,15 +100,11 @@ class RecallMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
     # ------------------------------------------------------------------------
     # AbstractGeneratesDataSpecification overrides
     # ------------------------------------------------------------------------
-    @inject_items({"machine_time_step": "MachineTimeStep",
-                   "time_scale_factor": "TimeScaleFactor",
-                   "routing_info": "MemoryRoutingInfos"})
+    @inject_items({"routing_info": "MemoryRoutingInfos"})
     @overrides(AbstractGeneratesDataSpecification.generate_data_specification,
-               additional_arguments={"machine_time_step", "time_scale_factor",
-                                     "routing_info"}
+               additional_arguments={"routing_info"}
                )
-    def generate_data_specification(self, spec, placement, machine_time_step,
-                                    time_scale_factor, routing_info):
+    def generate_data_specification(self, spec, placement, routing_info):
         vertex = placement.vertex
 
         spec.comment("\n*** Spec for Recall Instance ***\n\n")
@@ -135,8 +131,7 @@ class RecallMachineVertex(MachineVertex, AbstractGeneratesDataSpecification,
         spec.switch_write_focus(
             self._RECALL_REGIONS.SYSTEM.value)
         spec.write_array(simulation_utilities.get_simulation_header_array(
-            vertex.get_binary_file_name(), machine_time_step,
-            time_scale_factor))
+            vertex.get_binary_file_name()))
 
         # Write recall region containing routing key to transmit with
         spec.comment("\nWriting recall region:\n")

--- a/unittests/test_cfg_checker.py
+++ b/unittests/test_cfg_checker.py
@@ -1,0 +1,38 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+from spinn_utilities.config_holder import run_config_checks
+# This imports AbstractSpiNNakerCommon which calls set_cfg_files
+import spynnaker8  # noqa: F401
+
+
+class TestCfgChecker(unittest.TestCase):
+
+    def test_config_checks(self):
+        unittests = os.path.dirname(__file__)
+        parent = os.path.dirname(unittests)
+        spinn_gym = os.path.join(parent, "spinn_gym")
+        examples = os.path.join(parent, "examples")
+        integration_tests = os.path.join(parent, "integration_tests")
+        repeaters = [
+            "application_to_machine_graph_algorithms",
+            "machine_graph_to_machine_algorithms",
+            "machine_graph_to_virtual_machine_algorithms",
+            "loading_algorithms"]
+        run_config_checks(directories=[
+            spinn_gym, examples, integration_tests, unittests],
+            repeaters=repeaters)

--- a/unittests/test_import_all.py
+++ b/unittests/test_import_all.py
@@ -1,0 +1,42 @@
+# Copyright (c) 2017-2019 The University of Manchester
+#
+# This program is free software: you can redistribute it and/or modify
+# it under the terms of the GNU General Public License as published by
+# the Free Software Foundation, either version 3 of the License, or
+# (at your option) any later version.
+#
+# This program is distributed in the hope that it will be useful,
+# but WITHOUT ANY WARRANTY; without even the implied warranty of
+# MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+# GNU General Public License for more details.
+#
+# You should have received a copy of the GNU General Public License
+# along with this program.  If not, see <http://www.gnu.org/licenses/>.
+
+import os
+import unittest
+import spinn_utilities.package_loader as package_loader
+
+
+class ImportAllModule(unittest.TestCase):
+
+    def test_import_all(self):
+        if os.environ.get('CONTINUOUS_INTEGRATION', 'false').lower() == 'true':
+            package_loader.load_module("spinn_gym", remove_pyc_files=False)
+        else:
+            # Do a full stack cleanup
+            package_loader.load_module(
+                "spinn_utilities", remove_pyc_files=True)
+            package_loader.load_module("spinn_machine", remove_pyc_files=True)
+            package_loader.load_module("spinnman", remove_pyc_files=True)
+            package_loader.load_module("pacman", remove_pyc_files=True)
+            package_loader.load_module(
+                "data_specification", remove_pyc_files=True)
+            package_loader.load_module(
+                "spalloc", remove_pyc_files=True)
+            package_loader.load_module(
+                "spinn_front_end_common", remove_pyc_files=True)
+            # Test the files
+            package_loader.load_module("spynnaker", remove_pyc_files=True)
+            package_loader.load_module("spynnaker8", remove_pyc_files=True)
+            package_loader.load_module("spinn_gym", remove_pyc_files=True)


### PR DESCRIPTION
part of SpiNNakerManchester/SpiNNFrontEndCommon#792

the main change here is that the API's no longer have parameters this work did not use.

Add the two default unitests while here