### PR TITLE
Cap opencv-python version for now

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -24,4 +24,4 @@ numpy == 1.19; python_version == '3.6'
 numpy >= 1.19, <= 1.20; python_version == '3.7'
 numpy; python_version >= '3.8'
 lxml
-opencv-python
+opencv-python == 4.5.3.56


### PR DESCRIPTION
Cap opencv-python at previous version to the current release.