### PR TITLE
Added missing requirements in setup.py

### DIFF
--- a/setup.py
+++ b/setup.py
@@ -28,7 +28,9 @@ install_requires = [
     'SpiNNaker_PACMAN == 1!6.0.1',
     'SpiNNaker_DataSpecification == 1!6.0.1',
     'spalloc == 1!6.0.1',
-    'SpiNNFrontEndCommon == 1!6.0.1']
+    'SpiNNFrontEndCommon == 1!6.0.1',
+    'sPyNNaker == 1!6.0.1',
+    'opencv-python']
 if os.environ.get('READTHEDOCS', None) != 'True':
 
     # scipy must be added in config.py as a mock


### PR DESCRIPTION
Uses aren't guaranteed to be via `requirements.txt` so we should state things in `setup.py` as well.