### PR TITLE
Drop support for python 3.6

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -18,7 +18,7 @@ on: [push]
 
 jobs:
   build:
-    runs-on: ubuntu-20.04
+    runs-on: ubuntu-latest
     strategy:
       matrix:
         python-version: [3.7, 3.8, 3.9, "3.10"]
@@ -60,7 +60,7 @@ jobs:
       uses: ./support/actions/pytest
       with:
         tests: unittests
-        coverage: ${{ matrix.python-version == 3.6 }}
+        coverage: ${{ matrix.python-version == 3.8 }}
         cover-packages: ${{ env.CODE_PATHS }}
         coveralls-token: ${{ secrets.COVERALLS_REPO_TOKEN }}
 


### PR DESCRIPTION
Drop python 3.6 as described in https://github.com/SpiNNakerManchester/SupportScripts/pull/43