### PR TITLE
Fix warning/error of unexpected keyword argument

### DIFF
--- a/spinn_gym/games/breakout/visualise_jupyter.py
+++ b/spinn_gym/games/breakout/visualise_jupyter.py
@@ -55,8 +55,8 @@ def handle_vis_spikes(label, time, neuron_ids, vis):
     vis.handle_breakout_spikes(time, neuron_ids)
 
 
-def handle_live_spikes(_label, _time, _neuron_ids, _vis):
-    _vis.handle_live_spikes(_label, _time, _neuron_ids)
+def handle_live_spikes(label, time, neuron_ids, vis):
+    vis.handle_live_spikes(label, time, neuron_ids)
 
 
 def jupyter_visualiser(

--- a/spinn_gym/games/breakout/visualise_jupyter.py
+++ b/spinn_gym/games/breakout/visualise_jupyter.py
@@ -16,7 +16,7 @@ import functools
 import threading
 import matplotlib.pyplot as plt
 import numpy as np
-import time
+from time import sleep
 
 import pyNN.spiNNaker as p
 from spinn_gym.games.breakout.visualiser.visualiser import Visualiser
@@ -39,7 +39,7 @@ def start_visualiser(vis, display_handle):
     while vis.running:
         if vis.update():
             display_handle.update(plt.gcf())
-        time.sleep(refresh_time)
+        sleep(refresh_time)
 
 
 def stop_visualiser(label, conn, vis, display_handle):
@@ -51,7 +51,7 @@ def stop_visualiser(label, conn, vis, display_handle):
 
 
 def handle_vis_spikes(label, time, neuron_ids, vis):
-    # pylint: disable=unused-argument, redefined-outer-name
+    # pylint: disable=unused-argument
     vis.handle_breakout_spikes(time, neuron_ids)
 
 


### PR DESCRIPTION
Recent linting caused a warning/error (see below) when trying to run the visualiser on Jupyter; this fixes it.

```
2023-03-06 12:54:57 WARNING: problem handling received packet
Traceback (most recent call last):
  File "/home/bbpnrsoa/sPyNNakerGit/SpiNNFrontEndCommon/spinn_front_end_common/utilities/connections/live_event_connection.py", line 372, in __do_receive_packet
    self.__handle_time_packet(packet)
  File "/home/bbpnrsoa/sPyNNakerGit/SpiNNFrontEndCommon/spinn_front_end_common/utilities/connections/live_event_connection.py", line 403, in __handle_time_packet
    c_back(label, time, atoms_times_labels[time][label_id])
TypeError: handle_live_spikes() got an unexpected keyword argument 'vis'
```