### PR TITLE
Instance of 'Block' has no 'segments' member (no-member)

### DIFF
--- a/.github/workflows/python_actions.yml
+++ b/.github/workflows/python_actions.yml
@@ -72,9 +72,12 @@ jobs:
 
     - name: Lint with flake8
       run: flake8 examples spinn_gym
+
+      # Instance of 'Block' has no 'segments' member (no-member)
     - name: Lint with pylint
       uses: ./support/actions/pylint
-      with: 
+      with:
+        disable: no-member
         package: examples spinn_gym
         exitcheck: 39
 


### PR DESCRIPTION
This disables pylint no-member as it is confused by PyNN duck typing

Alternative is to have ourt own Block which overwrite neo with a pass through method