### PR TITLE
Delays are never needed

### DIFF
--- a/examples/breakout/spynnaker.cfg
+++ b/examples/breakout/spynnaker.cfg
@@ -1,4 +1,0 @@
-[Mapping]
-
-# Breakout doesn't implement delays, so avoid DelaySupportAdder
-delay_support_adder = None

--- a/examples/double_inverted_pendulum/spynnaker.cfg
+++ b/examples/double_inverted_pendulum/spynnaker.cfg
@@ -1,4 +1,0 @@
-[Mapping]
-
-# Inverted Pendulum doesn't implement delay extensions, so avoid DelaySupportAdder
-delay_support_adder = None

--- a/examples/inverted_pendulum/spynnaker.cfg
+++ b/examples/inverted_pendulum/spynnaker.cfg
@@ -1,4 +1,0 @@
-[Mapping]
-
-# Inverted Pendulum doesn't implement delay extensions, so avoid DelaySupportAdder
-delay_support_adder = None

--- a/examples/logic/spynnaker.cfg
+++ b/examples/logic/spynnaker.cfg
@@ -1,4 +1,0 @@
-[Mapping]
-
-# Logic doesn't implement delay extensions, so avoid DelaySupportAdder
-delay_support_adder = None

--- a/examples/multi_arm_bandit/spynnaker.cfg
+++ b/examples/multi_arm_bandit/spynnaker.cfg
@@ -1,4 +1,0 @@
-[Mapping]
-
-# Inverted Pendulum doesn't implement delay extensions, so avoid DelaySupportAdder
-delay_support_adder = None

--- a/examples/store_recall/spynnaker.cfg
+++ b/examples/store_recall/spynnaker.cfg
@@ -1,4 +1,0 @@
-[Mapping]
-
-# Inverted Pendulum doesn't implement delay extensions, so avoid DelaySupportAdder
-delay_support_adder = None


### PR DESCRIPTION
remove the special case cfgs
related to: https://github.com/SpiNNakerManchester/sPyNNaker/issues/1192

cfg delay_support_adder = None is not needed as delays never needed.

There is a parallel 
https://github.com/SpiNNakerManchester/sPyNNaker/tree/no_delay
Which test this but can not be added as it error if a delay is needed

https://github.com/SpiNNakerManchester/IntegrationTests/tree/no_delay
tests this but also has most other tests stripped out
